### PR TITLE
Don't clone in mutable set

### DIFF
--- a/map.go
+++ b/map.go
@@ -191,7 +191,7 @@ func (self *tree) UnsafeMutableSet(key string, value interface{}) Map {
 
 func mutableSetLowLevel(self *tree, partialHash, hash uint64, key string, value interface{}) *tree {
 	if self.IsNil() { // an empty tree is easy
-		m := self.clone()
+		m := self
 		m.count = 1
 		m.hash = hash
 		m.key = key


### PR DESCRIPTION
I think this was an oversight - the whole point of `UnsafeMutableSet` is to overwrite the value supplied, so cloning and returning a different one is wrong, and causes extra memory allocations.