### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/map.go
+++ b/map.go
@@ -12,6 +12,7 @@ package ps
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -125,9 +126,14 @@ func bytesView(v string) []byte {
 		return zeroByteSlice
 	}
 
+	b := make([]byte, 0)
 	sx := (*unsafeString)(unsafe.Pointer(&v))
-	bx := unsafeSlice{sx.Data, sx.Len, sx.Len}
-	return *(*[]byte)(unsafe.Pointer(&bx))
+	bx := (*unsafeSlice)(unsafe.Pointer(&b))
+	bx.Data = sx.Data
+	bx.Cap = sx.Len
+	bx.Len = sx.Len
+	runtime.KeepAlive(v)
+	return b
 }
 
 // hashKey returns a hash code for a given string


### PR DESCRIPTION
I found an incorrect cast from `string` to `[]byte` in `map.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.